### PR TITLE
Walker class doesn't exist, stop execution

### DIFF
--- a/extended-taxos.php
+++ b/extended-taxos.php
@@ -598,8 +598,9 @@ class Extended_Taxonomy_Admin {
 /**
  *  If the walker class doesn't exist, stop execution 
  */
-if(!class_exists('Walker'))
+if(!class_exists('Walker')){
     return;
+}
 
 /**
  * Walker to output an unordered list of category checkbox <input> elements properly.


### PR DESCRIPTION
Added in a if statement to check if walker class exists. This check was put in place to stop these classes fatal erring when using WP-CLI. 
