### PR TITLE
Add a function exists check

### DIFF
--- a/extended-taxos.php
+++ b/extended-taxos.php
@@ -40,6 +40,7 @@ GNU General Public License for more details.
 
 */
 
+if ( ! function_exists( 'register_extended_taxonomy' ) ) :
 
 /**
  * Wrapper function for instantiating a new ExtendedTaxonomy object. This is the only function you need.
@@ -856,3 +857,5 @@ class Walker_ExtendedTaxonomyDropdown extends Walker {
 	}
 
 }
+
+endif;


### PR DESCRIPTION
Personally, I'd probably split the classes out into individual files so everything could be aligned properly without making the files unreadable. As it stands, this will make PHP_CodeSniffer spazz out when running the WordPress coding standards. Still, it's better than not having the check in place. :)
