### PR TITLE
Add autoload to composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
 	},
 	"suggest": {
 		"wpackagist-plugin/rewrite-testing": "Rewrite Rule Testing"
+	},
+	"autoload": {
+		"files": ["extended-taxos.php"]
 	}
 }


### PR DESCRIPTION
This would be useful for folks using Composer and WordPress together so they don't have to load the file manually, same thing has been proposed to https://github.com/johnbillion/extended-cpts/pull/36