### PR TITLE
Case when init is already triggered, but taxonomy creation is not done using extended-taxos

### DIFF
--- a/extended-taxos.php
+++ b/extended-taxos.php
@@ -297,6 +297,7 @@ class Extended_Taxonomy_Admin {
 		'dashboard_glance'  => false, # Custom arg
 		'checked_ontop'     => null,  # Custom arg
 		'admin_cols'        => null,  # Custom arg
+		'required'          => false,  # Custom arg
 	);
 
 	public $taxo;
@@ -716,6 +717,7 @@ class Extended_Taxonomy_Admin {
 						'name'              => "tax_input[{$taxonomy}]",
 						'taxonomy'          => $taxonomy,
 						'walker'            => $walker,
+						'required'          => $this->args['required'],
 					) );
 
 					break;

--- a/extended-taxos.php
+++ b/extended-taxos.php
@@ -228,8 +228,8 @@ class Extended_Taxonomy {
 		}
 
 		# Register taxonomy when WordPress initialises:
-		if ( 'init' === current_filter() ) {
-			call_user_func( array( $this, 'register_taxonomy' ) );
+		if ( did_action( 'init' ) ) {
+			$this->register_taxonomy();
 		} else {
 			add_action( 'init', array( $this, 'register_taxonomy' ), 9 );
 		}

--- a/extended-taxos.php
+++ b/extended-taxos.php
@@ -228,7 +228,7 @@ class Extended_Taxonomy {
 		}
 
 		# Register taxonomy when WordPress initialises:
-		if ( did_action( 'init' ) ) {
+		if ( 'init' === current_filter() || did_action( 'init' ) ) {
 			$this->register_taxonomy();
 		} else {
 			add_action( 'init', array( $this, 'register_taxonomy' ), 9 );


### PR DESCRIPTION
When using the platform , it doesn't creates a problem, as the current init action would take care of this. But while writing test cases, register_extended_taxonomy doesn't creates a taxonomy.

But while using the register_post_type, it did.   Updating the pr as per Extended_CPTS plugin.

@johnbillion : Please have a look